### PR TITLE
Database caching

### DIFF
--- a/app/bundles/CoreBundle/Command/GenerateMigrationsCommand.php
+++ b/app/bundles/CoreBundle/Command/GenerateMigrationsCommand.php
@@ -48,7 +48,8 @@ class GenerateMigrationsCommand extends AbstractCommand
 {
     private static $_template =
             '<?php
-/**
+
+/*
  * @package     Mautic
  * @copyright   <year> Mautic Contributors. All rights reserved.
  * @author      Mautic

--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -527,13 +527,24 @@ return [
                     'request_stack',
                 ],
             ],
+            'mautic.helper.cache_storage' => [
+                'class'     => 'Mautic\CoreBundle\Helper\CacheStorageHelper',
+                'arguments' => [
+                    '"db"',
+                    '%mautic.db_table_prefix%',
+                    'doctrine.dbal.default_connection',
+                    '%kernel.cache_dir%',
+                ],
+            ],
             'mautic.helper.update' => [
                 'class'     => 'Mautic\CoreBundle\Helper\UpdateHelper',
                 'arguments' => 'mautic.factory',
             ],
             'mautic.helper.cache' => [
                 'class'     => 'Mautic\CoreBundle\Helper\CacheHelper',
-                'arguments' => 'mautic.factory',
+                'arguments' => [
+                    'kernel',
+                ],
             ],
             'mautic.helper.templating' => [
                 'class'     => 'Mautic\CoreBundle\Helper\TemplatingHelper',

--- a/app/bundles/CoreBundle/Entity/Cache.php
+++ b/app/bundles/CoreBundle/Entity/Cache.php
@@ -1,0 +1,157 @@
+<?php
+
+/*
+ * @copyright   2016 Mautic Contributors. All rights reserved
+ * @author      Mautic, Inc.
+ *
+ * @link        https://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\CoreBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+class Cache
+{
+    /**
+     * @var int
+     */
+    private $id;
+
+    /**
+     * @var string
+     */
+    private $data;
+
+    /**
+     * @var int
+     */
+    private $lifetime;
+
+    /**
+     * @var int
+     */
+    private $time;
+
+    /**
+     * @param ORM\ClassMetadata $metadata
+     */
+    public static function loadMetadata(ORM\ClassMetadata $metadata)
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+        $builder->setTable('cache_items');
+
+        $builder->createField('id', 'binary')
+                ->columnName('item_id')
+                ->makePrimaryKey()
+                ->build();
+
+        $builder->addNamedField('data', 'blob', 'item_data');
+
+        $builder->addField(
+            'lifetime',
+            'integer',
+            [
+                'columnName' => 'item_lifetime',
+                'nullable'   => true,
+                'options'    => [
+                    'unsigned' => true,
+                ],
+            ]
+        );
+
+        $builder->addField(
+            'time',
+            'integer',
+            [
+                'columnName' => 'item_time',
+                'options'    => [
+                        'unsigned' => true,
+                    ],
+            ]
+        );
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return Cache
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * @param string $data
+     *
+     * @return Cache
+     */
+    public function setData($data)
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLifetime()
+    {
+        return $this->lifetime;
+    }
+
+    /**
+     * @param int $lifetime
+     *
+     * @return Cache
+     */
+    public function setLifetime($lifetime)
+    {
+        $this->lifetime = $lifetime;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTime()
+    {
+        return $this->time;
+    }
+
+    /**
+     * @param int $time
+     *
+     * @return Cache
+     */
+    public function setTime($time)
+    {
+        $this->time = $time;
+
+        return $this;
+    }
+}

--- a/app/bundles/CoreBundle/Helper/CacheHelper.php
+++ b/app/bundles/CoreBundle/Helper/CacheHelper.php
@@ -11,37 +11,37 @@
 
 namespace Mautic\CoreBundle\Helper;
 
-use Mautic\CoreBundle\Factory\MauticFactory;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * Class CacheHelper.
  */
 class CacheHelper
 {
-    protected $factory;
-
     protected $cacheDir;
-
-    protected $env;
 
     protected $configFile;
 
     protected $containerFile;
 
+    protected $container;
+
     /**
-     * @param MauticFactory $factory
+     * CacheHelper constructor.
+     *
+     * @param \AppKernel $kernel
      */
-    public function __construct(MauticFactory $factory)
+    public function __construct(\AppKernel $kernel)
     {
-        $this->factory       = $factory;
-        $this->cacheDir      = $factory->getSystemPath('cache', true);
-        $this->env           = $factory->getEnvironment();
-        $this->configFile    = $this->factory->getLocalConfigFile(false);
-        $this->containerFile = $this->factory->getKernel()->getContainerFile();
+        $this->kernel        = $kernel;
+        $this->cacheDir      = $this->container()->get('mautic.helper.paths')->getSystemPath('cache', true);
+        $this->configFile    = $kernel->getLocalConfigFile(false);
+        $this->containerFile = $kernel->getContainerFile();
+        $this->container     = $kernel->getContainer();
     }
 
     /**
@@ -60,14 +60,14 @@ class CacheHelper
         //attempt to squash command output
         ob_start();
 
-        $args = ['console', 'cache:clear', '--env='.$this->env];
+        $args = ['console', 'cache:clear', '--env='.MAUTIC_ENV];
 
-        if ($this->env == 'prod') {
+        if (MAUTIC_ENV == 'prod') {
             $args[] = '--no-debug';
         }
 
         $input       = new ArgvInput($args);
-        $application = new Application($this->factory->getKernel());
+        $application = new Application($this->kernel);
         $application->setAutoExit(false);
         $output = new NullOutput();
         $application->run($input, $output);
@@ -99,9 +99,8 @@ class CacheHelper
     {
         $this->clearSessionItems();
 
-        $containerFile = $this->factory->getKernel()->getContainerFile();
-        if (file_exists($containerFile)) {
-            unlink($containerFile);
+        if (file_exists($this->containerFile)) {
+            unlink($this->containerFile);
         }
 
         $this->clearOpcaches($configSave);
@@ -131,8 +130,8 @@ class CacheHelper
     public function clearRoutingCache()
     {
         $unlink = [
-            $this->factory->getKernel()->getContainer()->getParameter('router.options.generator.cache_class'),
-            $this->factory->getKernel()->getContainer()->getParameter('router.options.matcher.cache_class'),
+            $this->kernel->getContainer()->getParameter('router.options.generator.cache_class'),
+            $this->kernel->getContainer()->getParameter('router.options.matcher.cache_class'),
         ];
 
         foreach ($unlink as $file) {
@@ -148,7 +147,7 @@ class CacheHelper
     protected function clearSessionItems()
     {
         // Clear the menu items and icons so they can be rebuilt
-        $session = $this->factory->getSession();
+        $session = $this->kernel->getContainer()->get('session');
         $session->remove('mautic.menu.items');
         $session->remove('mautic.menu.icons');
     }

--- a/app/bundles/CoreBundle/Helper/CacheHelper.php
+++ b/app/bundles/CoreBundle/Helper/CacheHelper.php
@@ -38,10 +38,10 @@ class CacheHelper
     public function __construct(\AppKernel $kernel)
     {
         $this->kernel        = $kernel;
-        $this->cacheDir      = $this->container()->get('mautic.helper.paths')->getSystemPath('cache', true);
+        $this->container     = $kernel->getContainer();
+        $this->cacheDir      = $this->container->get('mautic.helper.paths')->getSystemPath('cache', true);
         $this->configFile    = $kernel->getLocalConfigFile(false);
         $this->containerFile = $kernel->getContainerFile();
-        $this->container     = $kernel->getContainer();
     }
 
     /**

--- a/app/bundles/CoreBundle/Helper/CacheStorageHelper.php
+++ b/app/bundles/CoreBundle/Helper/CacheStorageHelper.php
@@ -116,6 +116,10 @@ class CacheStorageHelper
         } elseif (isset($this->expirations[$name])) {
             // @deprecated BC support to be removed in 3.0
             $cacheItem->expiresAfter($this->expirations[$name]);
+        } elseif ($data === $cacheItem->get()) {
+            // Exact same data so don't update the cache unless expiration is set
+
+            return false;
         }
 
         $cacheItem->set($data);

--- a/app/bundles/CoreBundle/Helper/CacheStorageHelper.php
+++ b/app/bundles/CoreBundle/Helper/CacheStorageHelper.php
@@ -112,7 +112,7 @@ class CacheStorageHelper
         $cacheItem = $this->cacheAdaptor->getItem($name);
 
         if (null !== $expiration) {
-            $cacheItem->expiresAfter($expiration);
+            $cacheItem->expiresAfter((int) $expiration);
         } elseif (isset($this->expirations[$name])) {
             // @deprecated BC support to be removed in 3.0
             $cacheItem->expiresAfter($this->expirations[$name]);
@@ -120,7 +120,7 @@ class CacheStorageHelper
 
         $cacheItem->set($data);
 
-        return $this->cacheAdaptor->save($cacheItem);
+        $this->cacheAdaptor->save($cacheItem);
     }
 
     /**
@@ -134,7 +134,7 @@ class CacheStorageHelper
         if (0 === $maxAge) {
             return false;
         } elseif (null !== $maxAge) {
-            $this->expirations[$name] = $maxAge;
+            $this->expirations[$name] = (int) $maxAge;
         }
 
         $cacheItem = $this->cacheAdaptor->getItem($name);
@@ -175,7 +175,7 @@ class CacheStorageHelper
      * @param null $namespace
      * @param null $defaultExpiration
      *
-     * @return $this;
+     * @return CacheStorageHelper;
      */
     public function getCache($namespace = null, $defaultExpiration = 0)
     {
@@ -188,7 +188,7 @@ class CacheStorageHelper
         }
 
         if (!isset($this->cache[$namespace])) {
-            $this->cache[$namespace] = new self($this->adaptor, $namespace, $this->connection, $this->cacheDir, $defaultExpiration);
+            $this->cache[$namespace] = new self($this->adaptor, $namespace, $this->connection, $this->cacheDir, (int) $defaultExpiration);
         }
 
         return $this->cache[$namespace];

--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -220,7 +220,7 @@ class InputHelper
         }
 
         if (!empty($allowedCharacters)) {
-            $regex = '/[^0-9a-z'.implode('', $allowedCharacters).']+/i';
+            $regex = '/[^0-9a-z'.preg_quote(implode('', $allowedCharacters)).']+/i';
         } else {
             $regex = '/[^0-9a-z]+/i';
         }

--- a/app/bundles/PluginBundle/Controller/PluginController.php
+++ b/app/bundles/PluginBundle/Controller/PluginController.php
@@ -17,6 +17,7 @@ use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\PluginBundle\Entity\Plugin;
 use Mautic\PluginBundle\Event\PluginIntegrationAuthRedirectEvent;
 use Mautic\PluginBundle\Event\PluginIntegrationEvent;
+use Mautic\PluginBundle\Model\PluginModel;
 use Mautic\PluginBundle\PluginEvents;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -155,6 +156,7 @@ class PluginController extends FormController
             throw $this->createNotFoundException($this->get('translator')->trans('mautic.core.url.error.404'));
         }
 
+        /** @var PluginModel $pluginModel */
         $pluginModel = $this->getModel('plugin');
 
         $leadFields    = $pluginModel->getLeadFields();

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -55,6 +55,11 @@ abstract class AbstractIntegration
     protected $cache;
 
     /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    protected $em;
+
+    /**
      * @param MauticFactory $factory
      *
      * @todo divorce from MauticFactory
@@ -64,6 +69,7 @@ abstract class AbstractIntegration
         $this->factory    = $factory;
         $this->dispatcher = $factory->getDispatcher();
         $this->cache      = $this->dispatcher->getContainer()->get('mautic.helper.cache_storage')->getCache($this->getName());
+        $this->em         = $factory->getEntityManager();
 
         $this->init();
     }
@@ -1249,7 +1255,8 @@ abstract class AbstractIntegration
     public function getAvailableLeadFields($settings = [])
     {
         if (empty($settings['ignore_field_cache'])) {
-            if ($fields = $this->cache->get('leadFields')) {
+            $prefix = (isset($settings['cache_suffix'])) ? '.'.$settings['cache_suffix'] : '';
+            if ($fields = $this->cache->get('leadFields'.$prefix)) {
                 return $fields;
             }
         }

--- a/app/migrations/Version20170113015255.php
+++ b/app/migrations/Version20170113015255.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * @package     Mautic
+ * @copyright   2017 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+/**
+ * Class Version20170113015255.
+ */
+class Version20170113015255 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     *
+     * @throws SkipMigrationException
+     * @throws \Doctrine\DBAL\Schema\SchemaException
+     */
+    public function preUp(Schema $schema)
+    {
+        if ($schema->hasTable(MAUTIC_TABLE_PREFIX.'cache_items')) {
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql("CREATE TABLE {$this->prefix}cache_items (item_id VARBINARY(255) NOT NULL PRIMARY KEY, item_data MEDIUMBLOB NOT NULL, item_lifetime INTEGER UNSIGNED, item_time INTEGER UNSIGNED NOT NULL) COLLATE utf8_bin, ENGINE = InnoDB");
+    }
+}

--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -87,14 +87,7 @@ class SalesforceApi extends CrmApi
             $object = 'Account'; //salesforce object name
         }
 
-        $leadFields = $this->integration->getCache()->getItem('leadFields.'.$object);
-
-        if (!$leadFields->isHit()) {
-            $leadFields->set($this->request('describe', [], 'GET', false, $object));
-            $this->integration->getCache()->save($leadFields);
-        }
-
-        return $leadFields->get();
+        return $this->request('describe', [], 'GET', false, $object);
     }
 
     /**
@@ -248,19 +241,20 @@ class SalesforceApi extends CrmApi
         return $result;
     }
 
+    /**
+     * @return mixed
+     */
     public function getOrganizationCreatedDate()
     {
         $cache = $this->integration->getCache();
 
-        $organizationCreatedDate = $cache->getItem('organization.created_date');
-
-        if (!$organizationCreatedDate->isHit()) {
-            $queryUrl     = $this->integration->getQueryUrl();
-            $organization = $this->request('query', ['q' => 'SELECT CreatedDate from Organization'], 'GET', false, null, $queryUrl);
-            $organizationCreatedDate->set($organization['records'][0]['CreatedDate']);
-            $cache->save($organizationCreatedDate);
+        if (!$organizationCreatedDate = $cache->get('organization.created_date')) {
+            $queryUrl                = $this->integration->getQueryUrl();
+            $organization            = $this->request('query', ['q' => 'SELECT CreatedDate from Organization'], 'GET', false, null, $queryUrl);
+            $organizationCreatedDate = $organization['records'][0]['CreatedDate'];
+            $cache->set('organization.created_date', $organizationCreatedDate);
         }
 
-        return $organizationCreatedDate->get();
+        return $organizationCreatedDate;
     }
 }

--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -221,7 +221,7 @@ class SalesforceApi extends CrmApi
         } else {
             $settings['feature_settings']['objects'][] = $object;
             $fields                                    = $this->integration->getAvailableLeadFields($settings);
-            $fields                                    = $this->integration->ammendToSfFields($fields);
+            $fields                                    = $this->integration->amendToSfFields($fields);
         }
 
         if (!empty($fields) and isset($query['start'])) {

--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -16,6 +16,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Helper\IdentifyCompanyHelper;
 use Mautic\PluginBundle\Entity\Integration;
 use Mautic\PluginBundle\Integration\AbstractIntegration;
+use Mautic\UserBundle\Entity\User;
 
 /**
  * Class CrmAbstractIntegration.
@@ -320,10 +321,10 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
             $lead->setInternal($internalInfo);
         }
 
-        if (isset($config['updateOwner']) && isset($config['updateOwner'][0]) && $config['updateOwner'][0] == 'updateOwner'
-            && isset($data['Owner__Lead']) && isset($data['Owner__Lead']['Email']) && strlen($data['Owner__Lead']['Email'])) {
+        // Update the owner if it matches (needs to be set by the integration) when fetching the data
+        if (isset($data['owner_email']) && isset($config['updateOwner']) && isset($config['updateOwner'][0]) && $config['updateOwner'][0] == 'updateOwner') {
             $mauticUser = $this->factory->getEntityManager()->getRepository('MauticUserBundle:User')
-                ->findOneBy(['email' => $data['Owner__Lead']['Email']]);
+                                        ->findOneBy(['email' => $data['owner_email']]);
             if ($mauticUser instanceof User) {
                 $lead->setOwner($mauticUser);
             }

--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -323,9 +323,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
 
         // Update the owner if it matches (needs to be set by the integration) when fetching the data
         if (isset($data['owner_email']) && isset($config['updateOwner']) && isset($config['updateOwner'][0]) && $config['updateOwner'][0] == 'updateOwner') {
-            $mauticUser = $this->factory->getEntityManager()->getRepository('MauticUserBundle:User')
-                                        ->findOneBy(['email' => $data['owner_email']]);
-            if ($mauticUser instanceof User) {
+            if ($mauticUser = $this->em->getRepository('MauticUserBundle:User')->findOneBy(['email' => $data['owner_email']])) {
                 $lead->setOwner($mauticUser);
             }
         }

--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -109,6 +109,10 @@ class HubspotIntegration extends CrmAbstractIntegration
      */
     public function getAvailableLeadFields($settings = [])
     {
+        if ($fields = parent::getAvailableLeadFields()) {
+            return $fields;
+        }
+
         $hubsFields        = [];
         $silenceExceptions = (isset($settings['silence_exceptions'])) ? $settings['silence_exceptions'] : true;
 
@@ -151,6 +155,8 @@ class HubspotIntegration extends CrmAbstractIntegration
                 throw $e;
             }
         }
+
+        $this->cache->set('leadFields', $hubsFields);
 
         return $hubsFields;
     }

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -165,6 +165,10 @@ class SugarcrmIntegration extends CrmAbstractIntegration
      */
     public function getAvailableLeadFields($settings = [])
     {
+        if ($fields = parent::getAvailableLeadFields($settings)) {
+            return $fields;
+        }
+
         $sugarFields       = [];
         $silenceExceptions = (isset($settings['silence_exceptions'])) ? $settings['silence_exceptions'] : true;
         try {
@@ -207,6 +211,8 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                 throw $e;
             }
         }
+
+        $this->cache->set('leadFields', $sugarFields);
 
         return $sugarFields;
     }

--- a/plugins/MauticCrmBundle/Integration/VtigerIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/VtigerIntegration.php
@@ -165,6 +165,10 @@ class VtigerIntegration extends CrmAbstractIntegration
      */
     public function getAvailableLeadFields($settings = [])
     {
+        if ($fields = parent::getAvailableLeadFields($settings)) {
+            return $fields;
+        }
+
         $vtigerFields      = [];
         $silenceExceptions = (isset($settings['silence_exceptions'])) ? $settings['silence_exceptions'] : true;
         try {
@@ -196,6 +200,8 @@ class VtigerIntegration extends CrmAbstractIntegration
 
             return false;
         }
+
+        $this->cache->set('leadFields', $vtigerFields);
 
         return $vtigerFields;
     }

--- a/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -143,6 +143,10 @@ class ZohoIntegration extends CrmAbstractIntegration
      */
     public function getAvailableLeadFields($settings = [])
     {
+        if ($fields = parent::getAvailableLeadFields($settings)) {
+            return $fields;
+        }
+
         $zohoFields        = [];
         $silenceExceptions = (isset($settings['silence_exceptions'])) ? $settings['silence_exceptions'] : true;
         try {
@@ -183,6 +187,8 @@ class ZohoIntegration extends CrmAbstractIntegration
 
             return false;
         }
+
+        $this->cache->set('leadFields', $zohoFields);
 
         return $zohoFields;
     }

--- a/plugins/MauticEmailMarketingBundle/Integration/MailchimpIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/MailchimpIntegration.php
@@ -105,6 +105,10 @@ class MailchimpIntegration extends EmailAbstractIntegration
      */
     public function getAvailableLeadFields($settings = [])
     {
+        if ($fields = parent::getAvailableLeadFields($settings)) {
+            return $fields;
+        }
+
         static $leadFields = [];
 
         if (empty($leadFields)) {
@@ -133,6 +137,8 @@ class MailchimpIntegration extends EmailAbstractIntegration
                 }
             }
         }
+
+        $this->cache->set('leadFields', $leadFields);
 
         return $leadFields;
     }


### PR DESCRIPTION
Using Symfony cache 3.2 which now comes with a PDO caching adaptor, I adapted your work to use the database as a caching mechanism by default. This will help scenarios where Mautic is running behind a load balancer and possibly using multiple web servers so that the data doesn't have to be cached on each server. I implemented caching into our existing CacheStorageHelper and abstracted the CRMs to all cache their fields. 

Also, while in there, I moved the Salesforce owner mapping to SalesforceIntegration and added support for Salesforce contact mapping as well. 

Ping me if you have any questions/concerns.  